### PR TITLE
Add HMAC request signing to protect AI chat endpoints

### DIFF
--- a/test-hmac.js
+++ b/test-hmac.js
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+/**
+ * Test script for HMAC request signature validation
+ *
+ * Usage: node test-hmac.js
+ *
+ * Prerequisites:
+ * - Dev server running: npm run dev
+ * - HMAC_SECRET configured in .env.local
+ */
+
+const crypto = require('crypto');
+
+// Configuration
+const BASE_URL = 'http://localhost:3000';
+const HMAC_SECRET = '772c22aaaf2444bbd6f859d2ae55c8847e59da949adc8aec0f37eeb5d68bb3f9';
+
+// Test payload
+const testBody = {
+  messages: [
+    { role: 'system', content: 'You are a helpful assistant.' },
+    { role: 'user', content: 'Say "HMAC test successful" if you can read this.' }
+  ],
+  max_tokens: 50
+};
+
+/**
+ * Generate HMAC signature for request
+ */
+function generateSignature(body, timestamp) {
+  const bodyText = JSON.stringify(body);
+  const payload = bodyText + timestamp;
+  return crypto.createHmac('sha256', HMAC_SECRET)
+    .update(payload)
+    .digest('hex');
+}
+
+/**
+ * Make authenticated request to API
+ */
+async function makeRequest(endpoint, body, signature, timestamp) {
+  const headers = {
+    'Content-Type': 'application/json',
+    'X-Device-Token': 'test-device-token',
+  };
+
+  if (signature) {
+    headers['X-Request-Signature'] = signature;
+  }
+  if (timestamp) {
+    headers['X-Request-Timestamp'] = timestamp;
+  }
+
+  const response = await fetch(`${BASE_URL}${endpoint}`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body)
+  });
+
+  return {
+    status: response.status,
+    headers: Object.fromEntries(response.headers.entries()),
+    body: await response.json().catch(() => ({}))
+  };
+}
+
+/**
+ * Run all tests
+ */
+async function runTests() {
+  console.log('🔐 Testing HMAC Request Signature Validation\n');
+  console.log('=' .repeat(60));
+
+  // Test 1: Valid signature
+  console.log('\n1️⃣  Test: Valid signature (should succeed)');
+  try {
+    const timestamp = Math.floor(Date.now() / 1000).toString();
+    const signature = generateSignature(testBody, timestamp);
+
+    console.log(`   Timestamp: ${timestamp}`);
+    console.log(`   Signature: ${signature.substring(0, 16)}...`);
+
+    const result = await makeRequest('/api/ai/chat/mini', testBody, signature, timestamp);
+
+    if (result.status === 200) {
+      console.log('   ✅ PASS: Request succeeded (status 200)');
+      console.log(`   Response: ${result.body.choices?.[0]?.message?.content?.substring(0, 50) || 'N/A'}...`);
+    } else {
+      console.log(`   ❌ FAIL: Expected 200, got ${result.status}`);
+      console.log(`   Error: ${result.body.error || 'Unknown'}`);
+    }
+  } catch (error) {
+    console.log(`   ❌ FAIL: ${error.message}`);
+  }
+
+  // Test 2: Invalid signature
+  console.log('\n2️⃣  Test: Invalid signature (should reject with 401)');
+  try {
+    const timestamp = Math.floor(Date.now() / 1000).toString();
+    const invalidSignature = 'invalid-signature-12345';
+
+    console.log(`   Timestamp: ${timestamp}`);
+    console.log(`   Signature: ${invalidSignature}`);
+
+    const result = await makeRequest('/api/ai/chat/mini', testBody, invalidSignature, timestamp);
+
+    if (result.status === 401) {
+      console.log('   ✅ PASS: Request rejected (status 401)');
+      console.log(`   Error: ${result.body.error}`);
+    } else {
+      console.log(`   ❌ FAIL: Expected 401, got ${result.status}`);
+    }
+  } catch (error) {
+    console.log(`   ❌ FAIL: ${error.message}`);
+  }
+
+  // Test 3: Missing signature
+  console.log('\n3️⃣  Test: Missing signature (should reject with 401)');
+  try {
+    const result = await makeRequest('/api/ai/chat/mini', testBody, null, null);
+
+    if (result.status === 401) {
+      console.log('   ✅ PASS: Request rejected (status 401)');
+      console.log(`   Error: ${result.body.error}`);
+    } else {
+      console.log(`   ❌ FAIL: Expected 401, got ${result.status}`);
+    }
+  } catch (error) {
+    console.log(`   ❌ FAIL: ${error.message}`);
+  }
+
+  // Test 4: Expired timestamp (6 minutes old)
+  console.log('\n4️⃣  Test: Expired timestamp (should reject with 401)');
+  try {
+    const expiredTimestamp = Math.floor((Date.now() - 6 * 60 * 1000) / 1000).toString();
+    const signature = generateSignature(testBody, expiredTimestamp);
+
+    console.log(`   Timestamp: ${expiredTimestamp} (6 minutes ago)`);
+    console.log(`   Signature: ${signature.substring(0, 16)}...`);
+
+    const result = await makeRequest('/api/ai/chat/mini', testBody, signature, expiredTimestamp);
+
+    if (result.status === 401) {
+      console.log('   ✅ PASS: Request rejected (status 401)');
+      console.log(`   Error: ${result.body.error}`);
+    } else {
+      console.log(`   ❌ FAIL: Expected 401, got ${result.status}`);
+    }
+  } catch (error) {
+    console.log(`   ❌ FAIL: ${error.message}`);
+  }
+
+  // Test 5: Future timestamp (should reject with 401)
+  console.log('\n5️⃣  Test: Future timestamp (should reject with 401)');
+  try {
+    const futureTimestamp = Math.floor((Date.now() + 10 * 1000) / 1000).toString();
+    const signature = generateSignature(testBody, futureTimestamp);
+
+    console.log(`   Timestamp: ${futureTimestamp} (10 seconds in future)`);
+    console.log(`   Signature: ${signature.substring(0, 16)}...`);
+
+    const result = await makeRequest('/api/ai/chat/mini', testBody, signature, futureTimestamp);
+
+    if (result.status === 401) {
+      console.log('   ✅ PASS: Request rejected (status 401)');
+      console.log(`   Error: ${result.body.error}`);
+    } else {
+      console.log(`   ❌ FAIL: Expected 401, got ${result.status}`);
+    }
+  } catch (error) {
+    console.log(`   ❌ FAIL: ${error.message}`);
+  }
+
+  console.log('\n' + '='.repeat(60));
+  console.log('\n✨ Tests complete!\n');
+}
+
+// Run tests
+runTests().catch(error => {
+  console.error('❌ Test suite failed:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Changes

Added HMAC-SHA256 request signature validation to both AI chat proxy endpoints to prevent unauthorized access and API abuse.

**Endpoints Protected:**
- `/api/ai/chat/mini` (gpt-4o-mini)
- `/api/ai/chat/standard` (gpt-4o)

**Security Features:**
- ✅ HMAC-SHA256 signature validation using shared secret
- ✅ 5-minute timestamp window to prevent replay attacks
- ✅ Returns 401 for missing, invalid, or expired signatures
- ✅ Signature calculation: `HMAC-SHA256(body + timestamp, HMAC_SECRET)`

**Implementation:**
- Moved request body parsing before rate limit check (needed for signature)
- Added signature and timestamp header validation
- Added timestamp age validation (prevents replay attacks)
- Added HMAC signature comparison
- Added error logging for invalid signatures

## Testing

Created comprehensive test script (`test-hmac.js`) with 5 test cases:

**Test Results:**
1. ✅ Valid signature - Accepted and processed
2. ✅ Invalid signature - Rejected with 401
3. ✅ Missing signature - Rejected with 401
4. ✅ Expired timestamp (6 min old) - Rejected with 401
5. ✅ Future timestamp - Rejected with 401

**Local Testing:**
```bash
# Start dev server
npm run dev

# Run tests
node test-hmac.js
```

## Deployment Requirements

**Environment Variable:**
```bash
# Generate secret
node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"

# Add to Vercel
HMAC_SECRET=<generated-secret>
```

**Vercel Setup:**
1. Go to Project Settings → Environment Variables
2. Add `HMAC_SECRET` with generated secret
3. Redeploy to apply changes

## Related Work

- Issue rustpoint/repkit#193 - iOS client implementation (adds `RequestSigner.swift`)
- Next steps: Update iOS app to sign requests with HMAC

## Screenshots

N/A - Backend security change, no UI impact

---

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>