### PR TITLE
[#667] Fix HMAC signature validation by using raw request body

### DIFF
--- a/app/api/ai/chat/standard/route.ts
+++ b/app/api/ai/chat/standard/route.ts
@@ -79,10 +79,14 @@ export async function POST(request: NextRequest) {
     const xffFirst = xff.split(",")[0]?.trim();
     const ip = cfIp || realIp || xffFirst || "0.0.0.0";
 
-    // Parse and validate request body (needed for HMAC signature validation)
+    // Get raw body text BEFORE parsing (needed for HMAC signature validation)
+    // CRITICAL: We must use the original request body text for signature validation
+    // because JSON.stringify(body) produces different output than Swift's JSONEncoder
+    let bodyText: string;
     let body: ChatCompletionRequest;
     try {
-      body = await request.json();
+      bodyText = await request.text();
+      body = JSON.parse(bodyText);
     } catch {
       return NextResponse.json(
         { error: "Invalid JSON body" },
@@ -124,7 +128,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const bodyText = JSON.stringify(body);
+    // Use the original body text for signature validation (not re-serialized)
     const payload = bodyText + timestamp;
     const expectedSignature = createHmac("sha256", secret)
       .update(payload)


### PR DESCRIPTION
## Summary

Fixes #667 - HMAC signature validation was failing because the server was re-serializing the JSON body with `JSON.stringify(body)`, which produces different output than Swift's `JSONEncoder`.

## Problem

The authentication flow was:
1. Swift client: Serialize request body with `JSONEncoder` → create HMAC signature
2. Server: Parse JSON with `request.json()` → re-serialize with `JSON.stringify(body)` → validate signature

The signature validation failed because `JSON.stringify()` and `JSONEncoder` produce different formatting:
- Different key ordering
- Different whitespace handling
- Different Unicode escape sequences

## Solution

Changed the server to:
1. Get raw body text with `request.text()` BEFORE parsing
2. Parse with `JSON.parse(bodyText)` for validation and processing
3. Use the original `bodyText` for HMAC signature validation

This ensures the HMAC signature is validated against the exact bytes that Swift sent, preventing serialization format differences from breaking authentication.

## Files Changed

- `/app/api/ai/chat/mini/route.ts` - Fixed HMAC validation for gpt-4o-mini endpoint
- `/app/api/ai/chat/standard/route.ts` - Fixed HMAC validation for gpt-4o endpoint

## Testing

Both endpoints now:
- Receive the raw request body text first
- Parse it for validation and processing
- Use the original text (not re-serialized) for signature validation

This preserves all existing functionality (rate limiting, error handling, logging) while fixing the authentication issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Validate HMAC using the original request body text (not re-serialized JSON) in both mini and standard chat routes.
> 
> - **Backend/API**:
>   - **HMAC Authentication**:
>     - Read raw body via `request.text()` and parse with `JSON.parse(bodyText)`.
>     - Use original `bodyText + timestamp` for signature calculation instead of `JSON.stringify(body)`.
>   - **Endpoints Updated**:
>     - `app/api/ai/chat/mini/route.ts`
>     - `app/api/ai/chat/standard/route.ts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5efb216998f3b4ce9047d11d43a531644e8b7375. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed signature validation consistency across AI chat endpoints for more reliable request verification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->